### PR TITLE
Fix double actions column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-/index.js
 storybook-static/
 coverage/

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ class App extends Component {
 
 export default App;
 ```
-
+**Attention :** the column id **"o2xpActions"** is reserved. Using it can result of unexpected behaviours.
 To go **further** check all [**examples**](https://github.com/o2xp/react-datatable/tree/develop/examples)
 
 ### Prop Types

--- a/data/customTableBodyRowSample.js
+++ b/data/customTableBodyRowSample.js
@@ -17,7 +17,7 @@ const customTableBodyRowSample = ({
 }) => {
   const { columns } = simpleOptionsSample.data;
   const columnAction = {
-    id: "actions",
+    id: "o2xpActions",
     label: "Actions",
     colSize: "150px",
     editable: false
@@ -33,7 +33,7 @@ const customTableBodyRowSample = ({
     >
       {columnsOrder.map(columnId => {
         const column =
-          columnId === "actions"
+          columnId === "o2xpActions"
             ? columnAction
             : columns.find(col => col.id === columnId);
         const width = `${(

--- a/data/customTableHeaderRowSample.js
+++ b/data/customTableHeaderRowSample.js
@@ -8,7 +8,7 @@ import { simpleOptionsSample } from "./samples";
 const customTableHeaderRowSample = ({ columnsOrder, columnSizeMultiplier }) => {
   const { columns } = simpleOptionsSample.data;
   const columnAction = {
-    id: "actions",
+    id: "o2xpActions",
     label: "Actions",
     colSize: "150px",
     editable: false
@@ -17,7 +17,7 @@ const customTableHeaderRowSample = ({ columnsOrder, columnSizeMultiplier }) => {
     <div className="Table-Row">
       {columnsOrder.map(columnId => {
         const column =
-          columnId === "actions"
+          columnId === "o2xpActions"
             ? columnAction
             : columns.find(col => col.id === columnId);
         const width = `${(

--- a/data/mergedDatableReducerRowsEdited.js
+++ b/data/mergedDatableReducerRowsEdited.js
@@ -49,7 +49,7 @@ const mergedDatableReducerRowsEdited = {
     ...features,
     userConfiguration: {
       ...userConfiguration,
-      columnsOrder: ["actions", ...userConfiguration.columnsOrder]
+      columnsOrder: ["o2xpActions", ...userConfiguration.columnsOrder]
     },
     additionalIcons: []
   }

--- a/data/mergedMaximumOptionsSample.js
+++ b/data/mergedMaximumOptionsSample.js
@@ -55,7 +55,7 @@ const mergedMaximumOptionsSample = {
     canOrderColumns: true,
     canSaveUserConfiguration: true,
     userConfiguration: {
-      columnsOrder: ["actions", "id", "name", "age"],
+      columnsOrder: ["o2xpActions", "id", "name", "age"],
       copyToClipboard: true
     },
     rowsPerPage: {

--- a/data/mergedSetRowsPerPageSample.js
+++ b/data/mergedSetRowsPerPageSample.js
@@ -48,7 +48,7 @@ const mergedSetRowsPerPageSample = {
     ...features,
     userConfiguration: {
       ...userConfiguration,
-      columnsOrder: ["actions", ...userConfiguration.columnsOrder]
+      columnsOrder: ["o2xpActions", ...userConfiguration.columnsOrder]
     },
     additionalIcons: []
   }

--- a/data/mergedSimpleOptionsSample.js
+++ b/data/mergedSimpleOptionsSample.js
@@ -46,7 +46,7 @@ const mergedSimpleOptionsSample = {
     ...features,
     userConfiguration: {
       ...userConfiguration,
-      columnsOrder: ["actions", ...userConfiguration.columnsOrder]
+      columnsOrder: ["o2xpActions", ...userConfiguration.columnsOrder]
     },
     additionalIcons: []
   }

--- a/data/mergedSimpleOptionsSampleCustomSize.js
+++ b/data/mergedSimpleOptionsSampleCustomSize.js
@@ -46,7 +46,7 @@ const mergedSimpleOptionsSampleCustomSize = {
     ...features,
     userConfiguration: {
       ...userConfiguration,
-      columnsOrder: ["actions", ...userConfiguration.columnsOrder]
+      columnsOrder: ["o2xpActions", ...userConfiguration.columnsOrder]
     },
     additionalIcons: []
   }

--- a/data/mergedSimpleOptionsSampleHeightResize.js
+++ b/data/mergedSimpleOptionsSampleHeightResize.js
@@ -50,7 +50,7 @@ const mergedSimpleOptionsSampleHeightResize = {
     ...features,
     userConfiguration: {
       ...userConfiguration,
-      columnsOrder: ["actions", ...userConfiguration.columnsOrder]
+      columnsOrder: ["o2xpActions", ...userConfiguration.columnsOrder]
     },
     additionalIcons: []
   }

--- a/data/mergedSimpleOptionsSampleWidthHeightResize.js
+++ b/data/mergedSimpleOptionsSampleWidthHeightResize.js
@@ -52,7 +52,7 @@ const mergedSimpleOptionsSampleWidthHeightResize = {
     ...features,
     userConfiguration: {
       ...userConfiguration,
-      columnsOrder: ["actions", ...userConfiguration.columnsOrder]
+      columnsOrder: ["o2xpActions", ...userConfiguration.columnsOrder]
     },
     additionalIcons: []
   }

--- a/data/mergedSimpleOptionsSampleWidthResize.js
+++ b/data/mergedSimpleOptionsSampleWidthResize.js
@@ -48,7 +48,7 @@ const mergedSimpleOptionsSampleWidthResize = {
     ...features,
     userConfiguration: {
       ...userConfiguration,
-      columnsOrder: ["actions", ...userConfiguration.columnsOrder]
+      columnsOrder: ["o2xpActions", ...userConfiguration.columnsOrder]
     },
     additionalIcons: []
   }

--- a/data/optionsObjectSample.js
+++ b/data/optionsObjectSample.js
@@ -32,8 +32,8 @@ export const dimensions = {
 export const keyColumn = "id";
 export const font = "Roboto";
 export const columnAction = {
-  id: "actions",
-  label: "",
+  id: "o2xpActions",
+  label: "Actions",
   colSize: "150px",
   editable: false
 };

--- a/examples/override/bodyRow.md
+++ b/examples/override/bodyRow.md
@@ -58,7 +58,7 @@ class App extends Component {
   }) => {
     let columns = options.data.columns;
     const columnAction = {
-      id: "actions",
+      id: "o2xpActions",
       label: "Actions",
       colSize: "150px",
       editable: false
@@ -72,7 +72,7 @@ class App extends Component {
       >
         {columnsOrder.map(columnId => {
           let column =
-            columnId === "actions"
+            columnId === "o2xpActions"
               ? columnAction
               : columns.find(col => col.id === columnId);
           const width = `${(

--- a/examples/override/headerRow.md
+++ b/examples/override/headerRow.md
@@ -52,7 +52,7 @@ class App extends Component {
   buildCustomTableHeaderRow = ({ columnsOrder, columnSizeMultiplier }) => {
     let columns = options.data.columns;
     const columnAction = {
-      id: "actions",
+      id: "o2xpActions",
       label: "Actions",
       colSize: "150px",
       editable: false
@@ -61,7 +61,7 @@ class App extends Component {
       <div className="Table-Row">
         {columnsOrder.map(columnId => {
           let column =
-            columnId === "actions"
+            columnId === "o2xpActions"
               ? columnAction
               : columns.find(col => col.id === columnId);
           const width = `${(

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/o2xp/react-datatable"
   },
-  "version": "1.0.5",
+  "version": "1.0.6",
   "dependencies": {
     "@date-io/moment": "^1.3.5",
     "@material-ui/core": "^3.9.3",

--- a/src/components/DatatableCore/Body/BodyRow.js
+++ b/src/components/DatatableCore/Body/BodyRow.js
@@ -46,7 +46,7 @@ export class BodyRow extends Component {
     const key = `row-${row[keyColumn]}-cell-${columnId}`;
     const isEditing = editing && column.editable;
 
-    if (columnId === "actions") {
+    if (columnId === "o2xpActions") {
       const checked = !!rowsSelected.find(r => r[keyColumn] === row[keyColumn]);
       return (
         <BodyActionsCell

--- a/src/components/DatatableCore/Header/HeaderRow.js
+++ b/src/components/DatatableCore/Header/HeaderRow.js
@@ -22,7 +22,7 @@ export class HeaderRow extends Component {
     ).toString()}px`;
     const key = `column-${columnId}`;
 
-    if (columnId === "actions") {
+    if (columnId === "o2xpActions") {
       return <HeaderActionsCell key={key} column={column} />;
     }
 

--- a/src/components/DatatableHeader/Widgets/ColumnsDisplayer.js
+++ b/src/components/DatatableHeader/Widgets/ColumnsDisplayer.js
@@ -43,7 +43,7 @@ export class ColumnsDisplayer extends Component {
     const { columnsOrder } = this.props;
     const { setColumnVisibilty } = this.props;
     const visible = columnsOrder.includes(column.id);
-    if (column.id !== "actions") {
+    if (column.id !== "o2xpActions") {
       return (
         <MenuItem key={column.id} onClick={() => setColumnVisibilty(column)}>
           <Checkbox checked={visible} color="primary" />

--- a/src/redux/reducers/datatableReducer.js
+++ b/src/redux/reducers/datatableReducer.js
@@ -113,10 +113,10 @@ const updateRowSizeMultiplier = state => {
 
   const widthColDisplayed = colDisplayed.map(col => {
     const column = col;
-    if (column.colSize && col.id !== "actions") {
+    if (column.colSize && col.id !== "o2xpActions") {
       return Number(column.colSize.split("px")[0]);
     }
-    if (col.id !== "actions") {
+    if (col.id !== "o2xpActions") {
       column.colSize = "100px";
       return 100;
     }
@@ -152,7 +152,7 @@ const totalWidth = state => {
   state.data.columns.forEach(col => {
     if (
       state.features.userConfiguration.columnsOrder.includes(col.id) &&
-      col.id !== "actions"
+      col.id !== "o2xpActions"
     ) {
       colDisplayed.push(col);
     }
@@ -278,9 +278,17 @@ const initializeOptions = (
 
   if (
     numberOfActions > 0 &&
-    !newState.data.columns.find(col => col.id === "actions")
+    !newState.data.columns.find(col => col.id === "o2xpActions")
   ) {
-    newState.features.userConfiguration.columnsOrder.unshift("actions");
+    newState.features.userConfiguration.columnsOrder = newState.features.userConfiguration.columnsOrder.filter(
+      colId => colId !== "o2xpActions"
+    );
+
+    newState.data.columns = newState.data.columns.filter(
+      column => column.id !== "o2xpActions"
+    );
+
+    newState.features.userConfiguration.columnsOrder.unshift("o2xpActions");
     let colSize = 0;
     switch (actionsUser.join(" ")) {
       case "true true true":
@@ -299,8 +307,8 @@ const initializeOptions = (
     }
 
     newState.data.columns.unshift({
-      id: "actions",
-      label: "",
+      id: "o2xpActions",
+      label: "Actions",
       colSize,
       editable: false
     });

--- a/test/componentsTest/DatatableCoreTest/BodyTest/BodyActionsCell.test.js
+++ b/test/componentsTest/DatatableCoreTest/BodyTest/BodyActionsCell.test.js
@@ -16,7 +16,7 @@ const revertRowEdited = jest.fn();
 const deleteRow = jest.fn();
 const selectRow = jest.fn();
 const column = {
-  id: "actions",
+  id: "o2xpActions",
   label: "Actions",
   colSize: "150px",
   editable: false

--- a/test/componentsTest/DatatableCoreTest/HeaderTest/HeaderActionsCell.test.js
+++ b/test/componentsTest/DatatableCoreTest/HeaderTest/HeaderActionsCell.test.js
@@ -11,7 +11,7 @@ const mockStore = configureStore();
 const store = mockStore(storeSample);
 
 const column = {
-  id: "actions",
+  id: "o2xpActions",
   label: "Actions",
   colSize: "150px",
   editable: false

--- a/test/reduxTest/reducersTest/datatableReducer.test.js
+++ b/test/reduxTest/reducersTest/datatableReducer.test.js
@@ -130,7 +130,7 @@ describe("datatableReducer reducer", () => {
       mergedSimpleOptionsSampleNoColSize.data.columns = mergedSimpleOptionsSampleNoColSize.data.columns.map(
         col => {
           const column = col;
-          column.colSize = col.id === "actions" ? "150px" : "100px";
+          column.colSize = col.id === "o2xpActions" ? "150px" : "100px";
           return column;
         }
       );
@@ -221,7 +221,7 @@ describe("datatableReducer reducer", () => {
       );
 
       mergedSimpleOptionsSampleSortColumns.features.userConfiguration.columnsOrder = [
-        "actions",
+        "o2xpActions",
         "name",
         "id",
         "age",
@@ -262,7 +262,7 @@ describe("datatableReducer reducer", () => {
       );
 
       mergedSimpleOptionsSampleSortColumns.features.userConfiguration.columnsOrder = [
-        "actions",
+        "o2xpActions",
         "name",
         "id",
         "adult",
@@ -296,7 +296,7 @@ describe("datatableReducer reducer", () => {
       );
 
       mergedSimpleOptionsSampleSortColumns.features.userConfiguration.columnsOrder = [
-        "actions",
+        "o2xpActions",
         "name",
         "age",
         "adult",
@@ -1252,7 +1252,7 @@ describe("datatableReducer reducer", () => {
           userConfiguration: {
             ...mergedSimpleOptionsSample.features.userConfiguration,
             columnsOrder: [
-              "actions",
+              "o2xpActions",
               "name",
               "age",
               "adult",
@@ -1284,7 +1284,7 @@ describe("datatableReducer reducer", () => {
           userConfiguration: {
             ...mergedSimpleOptionsSample.features.userConfiguration,
             columnsOrder: [
-              "actions",
+              "o2xpActions",
               "id",
               "name",
               "age",


### PR DESCRIPTION
## Proposed changes

Fixing bug where user give "o2xpActions" in columns order and it was displayed in double in the datatable. 

## Types of changes

What types of changes does your code introduce to @o2xp?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/o2xp/react-datatable/blob/develop/CONTRIBUTING.md) doc
- [x] I have signed the [CLA]()
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
