### PR TITLE
Fix bug causing blank page when array is empty and user click on "Display by presets" with o2xp library

### DIFF
--- a/src/components/DatatableHeader/Widgets/ColumnsDisplayer.js
+++ b/src/components/DatatableHeader/Widgets/ColumnsDisplayer.js
@@ -82,15 +82,18 @@ export class ColumnsDisplayer extends Component {
     const allPresets = columnsPresetsToDisplay.concat(localPresets);
 
     return allPresets.map(preset => {
-      return (
-        <MenuItem
-          key={preset.presetName}
-          onClick={() => handlePresetDisplay(preset)}
-        >
-          <Checkbox checked={preset.isActive} color="primary" />
-          {preset.presetName}
-        </MenuItem>
-      );
+      if (preset != null) {
+        return (
+          <MenuItem
+            key={preset.presetName}
+            onClick={() => handlePresetDisplay(preset)}
+          >
+            <Checkbox checked={preset.isActive} color="primary" />
+            {preset.presetName}
+          </MenuItem>
+        );
+      }
+      return <></>;
     });
   };
 


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to @o2xp/react-datatable?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code improvement

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/o2xp/react-datatable/blob/develop/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA]()
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
